### PR TITLE
Bring up to cctools-855; redo makefile; update script, etc.

### DIFF
--- a/include/mach-o/dyld.h
+++ b/include/mach-o/dyld.h
@@ -23,7 +23,7 @@
 #ifndef _MACH_O_DYLD_H_
 #define _MACH_O_DYLD_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
@@ -239,7 +239,7 @@ extern long NSVersionOfLinkTimeLibrary(
     const char *libraryName);
 extern int _NSGetExecutablePath( /* SPI first appeared in Mac OS X 10.2 */
     char *buf,
-    unsigned long *bufsize);
+    uint32_t *bufsize);
 
 /*
  * The low level _dyld_... API.
@@ -320,7 +320,7 @@ __private_extern__ int _dyld_func_lookup(
     const char *dyld_func_name,
     unsigned long *address);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif /* __cplusplus */
 

--- a/include/mach-o/loader.h
+++ b/include/mach-o/loader.h
@@ -294,6 +294,9 @@ struct load_command {
 #define LC_DATA_IN_CODE 0x29 /* table of non-instructions in __text */
 #define LC_SOURCE_VERSION 0x2A /* source version used to build binary */
 #define LC_DYLIB_CODE_SIGN_DRS 0x2B /* Code signing DRs copied from linked dylibs */
+#define	LC_ENCRYPTION_INFO_64 0x2C /* 64-bit encrypted segment information */
+#define LC_LINKER_OPTION 0x2D /* linker options in MH_OBJECT files */
+#define LC_LINKER_OPTIMIZATION_HINT 0x2E /* optimization hints in MH_OBJECT files */
 
 
 /*
@@ -1155,7 +1158,8 @@ struct rpath_command {
 struct linkedit_data_command {
     uint32_t	cmd;		/* LC_CODE_SIGNATURE, LC_SEGMENT_SPLIT_INFO,
                                    LC_FUNCTION_STARTS, LC_DATA_IN_CODE,
-				   or LC_DYLIB_CODE_SIGN_DRS */
+				   LC_DYLIB_CODE_SIGN_DRS or
+				   LC_LINKER_OPTIMIZATION_HINT. */
     uint32_t	cmdsize;	/* sizeof(struct linkedit_data_command) */
     uint32_t	dataoff;	/* file offset of data in __LINKEDIT segment */
     uint32_t	datasize;	/* file size of data in __LINKEDIT segment  */
@@ -1172,6 +1176,21 @@ struct encryption_info_command {
    uint32_t	cryptsize;	/* file size of encrypted range */
    uint32_t	cryptid;	/* which enryption system,
 				   0 means not-encrypted yet */
+};
+
+/*
+ * The encryption_info_command_64 contains the file offset and size of an
+ * of an encrypted segment (for use in x86_64 targets).
+ */
+struct encryption_info_command_64 {
+   uint32_t	cmd;		/* LC_ENCRYPTION_INFO_64 */
+   uint32_t	cmdsize;	/* sizeof(struct encryption_info_command_64) */
+   uint32_t	cryptoff;	/* file offset of encrypted range */
+   uint32_t	cryptsize;	/* file size of encrypted range */
+   uint32_t	cryptid;	/* which enryption system,
+				   0 means not-encrypted yet */
+   uint32_t	pad;		/* padding to make this struct's size a multiple
+				   of 8 bytes */
 };
 
 /*
@@ -1360,6 +1379,17 @@ struct dyld_info_command {
 #define EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER			0x10
 
 /*
+ * The linker_option_command contains linker options embedded in object files.
+ */
+struct linker_option_command {
+    uint32_t  cmd;	/* LC_LINKER_OPTION only used in MH_OBJECT filetypes */
+    uint32_t  cmdsize;
+    uint32_t  count;	/* number of strings */
+    /* concatenation of zero terminated UTF8 strings.
+       Zero filled at end to align */
+};
+
+/*
  * The symseg_command contains the offset and size of the GNU style
  * symbol table information as described in the header file <symseg.h>.
  * The symbol roots of the symbol segments must also be aligned properly
@@ -1428,19 +1458,18 @@ struct source_version_command {
 /*
  * The LC_DATA_IN_CODE load commands uses a linkedit_data_command 
  * to point to an array of data_in_code_entry entries. Each entry
- * describes a range of data in a code section.  This load command
- * is only used in final linked images.
+ * describes a range of data in a code section.
  */
 struct data_in_code_entry {
     uint32_t	offset;  /* from mach_header to start of data range*/
     uint16_t	length;  /* number of bytes in data range */
     uint16_t	kind;    /* a DICE_KIND_* value  */
 };
-#define DICE_KIND_DATA              0x0001  /* L$start$data$...  label */
-#define DICE_KIND_JUMP_TABLE8       0x0002  /* L$start$jt8$...   label */
-#define DICE_KIND_JUMP_TABLE16      0x0003  /* L$start$jt16$...  label */
-#define DICE_KIND_JUMP_TABLE32      0x0004  /* L$start$jt32$...  label */
-#define DICE_KIND_ABS_JUMP_TABLE32  0x0005  /* L$start$jta32$... label */
+#define DICE_KIND_DATA              0x0001
+#define DICE_KIND_JUMP_TABLE8       0x0002
+#define DICE_KIND_JUMP_TABLE16      0x0003
+#define DICE_KIND_JUMP_TABLE32      0x0004
+#define DICE_KIND_ABS_JUMP_TABLE32  0x0005
 
 
 

--- a/include/mach-o/nlist.h
+++ b/include/mach-o/nlist.h
@@ -297,14 +297,14 @@ struct nlist_64 {
 #define N_SYMBOL_RESOLVER  0x0100 
 
 #ifndef __STRICT_BSD__
-#if __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 /*
  * The function nlist(3) from the C library.
  */
 extern int nlist (const char *filename, struct nlist *list);
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif /* __cplusplus */
 #endif /* __STRICT_BSD__ */

--- a/include/mach/arm/_structs.h
+++ b/include/mach/arm/_structs.h
@@ -26,6 +26,24 @@ _STRUCT_ARM_EXCEPTION_STATE
 #endif /* __DARWIN_UNIX03 */
 
 #if __DARWIN_UNIX03
+#define _STRUCT_ARM_EXCEPTION_STATE64	struct __darwin_arm_exception_state64
+_STRUCT_ARM_EXCEPTION_STATE64
+{
+	__uint64_t	__far; /* Virtual Fault Address */
+	__uint32_t	__esr; /* Exception syndrome */
+	__uint32_t	__exception; /* number of arm exception taken */
+};
+#else /* !__DARWIN_UNIX03 */
+#define _STRUCT_ARM_EXCEPTION_STATE64	struct arm_exception_state64
+_STRUCT_ARM_EXCEPTION_STATE64
+{
+	__uint64_t	far; /* Virtual Fault Address */
+	__uint32_t	esr; /* Exception syndrome */
+	__uint32_t	exception; /* number of arm exception taken */
+};
+#endif /* __DARWIN_UNIX03 */
+
+#if __DARWIN_UNIX03
 #define _STRUCT_ARM_THREAD_STATE	struct __darwin_arm_thread_state
 _STRUCT_ARM_THREAD_STATE
 {
@@ -48,6 +66,30 @@ _STRUCT_ARM_THREAD_STATE
 #endif /* __DARWIN_UNIX03 */
 
 #if __DARWIN_UNIX03
+#define _STRUCT_ARM_THREAD_STATE64	struct __darwin_arm_thread_state64
+_STRUCT_ARM_THREAD_STATE64
+{
+	__uint64_t    __x[29];	/* General purpose registers x0-x28 */
+	__uint64_t    __fp;		/* Frame pointer x29 */
+	__uint64_t    __lr;		/* Link register x30 */
+	__uint64_t    __sp;		/* Stack pointer x31 */
+	__uint64_t    __pc;		/* Program counter */
+	__uint32_t    __cpsr;	/* Current program status register */
+};
+#else /* !__DARWIN_UNIX03 */
+#define _STRUCT_ARM_THREAD_STATE64	struct arm_thread_state64
+_STRUCT_ARM_THREAD_STATE64
+{
+	__uint64_t    x[29];	/* General purpose registers x0-x28 */
+	__uint64_t    fp;		/* Frame pointer x29 */
+	__uint64_t    lr;		/* Link register x30 */
+	__uint64_t    sp;		/* Stack pointer x31 */
+	__uint64_t    pc; 		/* Program counter */
+	__uint32_t    cpsr;		/* Current program status register */
+};
+#endif /* __DARWIN_UNIX03 */
+
+#if __DARWIN_UNIX03
 #define _STRUCT_ARM_VFP_STATE		struct __darwin_arm_vfp_state
 _STRUCT_ARM_VFP_STATE
 {
@@ -64,7 +106,88 @@ _STRUCT_ARM_VFP_STATE
 };
 #endif /* __DARWIN_UNIX03 */
 
-#define _STRUCT_ARM_DEBUG_STATE		struct __darwin_arm_debug_state
+#if __DARWIN_UNIX03
+#define _STRUCT_ARM_NEON_STATE64		struct __darwin_arm_neon_state64
+#define _STRUCT_ARM_NEON_STATE		struct __darwin_arm_neon_state
+
+#if defined(__arm64__)
+_STRUCT_ARM_NEON_STATE64
+{
+	__uint128_t       __v[32];
+	__uint32_t        __fpsr;
+	__uint32_t        __fpcr;
+};
+
+_STRUCT_ARM_NEON_STATE
+{
+	__uint128_t       __v[16];
+	__uint32_t        __fpsr;
+	__uint32_t        __fpcr;
+};
+
+#elif defined(__arm__)
+/*
+ * No 128-bit intrinsic for ARM; leave it opaque for now.
+ */
+_STRUCT_ARM_NEON_STATE64 
+{
+	char opaque[(32 * 16) + (2 * sizeof(__uint32_t))];
+} __attribute__((aligned(16)));
+
+_STRUCT_ARM_NEON_STATE
+{
+	char opaque[(16 * 16) + (2 * sizeof(__uint32_t))];
+} __attribute__((aligned(16)));
+
+#else
+/* #error Unknown architecture. */
+#endif
+
+#else /* !__DARWIN_UNIX03 */
+#define _STRUCT_ARM_NEON_STATE64 struct arm_neon_state64
+#define _STRUCT_ARM_NEON_STATE struct arm_neon_state
+
+#if defined(__arm64__)
+_STRUCT_ARM_NEON_STATE64
+{
+	__uint128_t		q[32];
+	uint32_t		fpsr;
+	uint32_t		fpcr;
+
+};
+_STRUCT_ARM_NEON_STATE
+{
+	__uint128_t		q[16];
+	uint32_t		fpsr;
+	uint32_t		fpcr;
+
+};
+#elif defined(__arm__)
+/*
+ * No 128-bit intrinsic for ARM; leave it opaque for now.
+ */
+_STRUCT_ARM_NEON_STATE64 
+{
+	char opaque[(32 * 16) + (2 * sizeof(__uint32_t))];
+} __attribute__((aligned(16)));
+
+_STRUCT_ARM_NEON_STATE
+{
+	char opaque[(16 * 16) + (2 * sizeof(__uint32_t))];
+} __attribute__((aligned(16)));
+
+#else
+#error Unknown architecture.
+#endif
+
+#endif /* __DARWIN_UNIX03 */
+
+/*
+ * Debug State
+ */
+#if defined(__arm__)
+#if __DARWIN_UNIX03
+#define _STRUCT_ARM_DEBUG_STATE	struct __darwin_arm_debug_state
 _STRUCT_ARM_DEBUG_STATE
 {
 	__uint32_t        __bvr[16];
@@ -72,5 +195,80 @@ _STRUCT_ARM_DEBUG_STATE
 	__uint32_t        __wvr[16];
 	__uint32_t        __wcr[16];
 };
+#else /* !__DARWIN_UNIX03 */
+#define _STRUCT_ARM_DEBUG_STATE	struct arm_debug_state
+_STRUCT_ARM_DEBUG_STATE
+{
+	__uint32_t        bvr[16];
+	__uint32_t        bcr[16];
+	__uint32_t        wvr[16];
+	__uint32_t        wcr[16];
+};
+#endif /* __DARWIN_UNIX03 */
+
+#elif defined(__arm64__)
+#if __DARWIN_UNIX03
+#define _STRUCT_ARM_LEGACY_DEBUG_STATE	struct arm_legacy_debug_state
+_STRUCT_ARM_LEGACY_DEBUG_STATE
+{
+	__uint32_t        __bvr[16];
+	__uint32_t        __bcr[16];
+	__uint32_t        __wvr[16];
+	__uint32_t        __wcr[16];
+};
+
+#define _STRUCT_ARM_DEBUG_STATE32	struct __darwin_arm_debug_state32
+_STRUCT_ARM_DEBUG_STATE32
+{
+	__uint32_t        __bvr[16];
+	__uint32_t        __bcr[16];
+	__uint32_t        __wvr[16];
+	__uint32_t        __wcr[16];
+	__uint64_t	  __mdscr_el1; /* Bit 0 is SS (Hardware Single Step) */
+};
+
+#define _STRUCT_ARM_DEBUG_STATE64	struct __darwin_arm_debug_state64
+_STRUCT_ARM_DEBUG_STATE64
+{
+	__uint64_t        __bvr[16];
+	__uint64_t        __bcr[16];
+	__uint64_t        __wvr[16];
+	__uint64_t        __wcr[16];
+	__uint64_t	  __mdscr_el1; /* Bit 0 is SS (Hardware Single Step) */
+};
+#else /* !__DARWIN_UNIX03 */
+#define _STRUCT_ARM_LEGACY_DEBUG_STATE	struct arm_legacy_debug_state
+_STRUCT_ARM_LEGACY_DEBUG_STATE
+{
+	__uint32_t        bvr[16];
+	__uint32_t        bcr[16];
+	__uint32_t        wvr[16];
+	__uint32_t        wcr[16];
+};
+
+#define _STRUCT_ARM_DEBUG_STATE32	struct arm_debug_state32
+_STRUCT_ARM_DEBUG_STATE32
+{
+	__uint32_t        bvr[16];
+	__uint32_t        bcr[16];
+	__uint32_t        wvr[16];
+	__uint32_t        wcr[16];
+	__uint64_t	  mdscr_el1; /* Bit 0 is SS (Hardware Single Step) */
+};
+
+#define _STRUCT_ARM_DEBUG_STATE64	struct arm_debug_state64
+_STRUCT_ARM_DEBUG_STATE64
+{
+	__uint64_t        bvr[16];
+	__uint64_t        bcr[16];
+	__uint64_t        wvr[16];
+	__uint64_t        wcr[16];
+	__uint64_t	  mdscr_el1; /* Bit 0 is SS (Hardware Single Step) */
+};
+#endif /* __DARWIN_UNIX03 */
+
+#else
+/* #error unknown architecture */
+#endif
 
 #endif /* _MACH_ARM__STRUCTS_H_ */

--- a/include/mach/arm/thread_state.h
+++ b/include/mach/arm/thread_state.h
@@ -14,4 +14,8 @@
 #define THREAD_STATE_MAX	ARM_THREAD_STATE_MAX
 #endif
 
+#if defined(__arm64__) && !defined(THREAD_STATE_MAX)
+#define THREAD_STATE_MAX	ARM_THREAD_STATE_MAX
+#endif
+
 #endif	/* _MACH_ARM_THREAD_STATE_H_ */

--- a/include/mach/arm/thread_status.h
+++ b/include/mach/arm/thread_status.h
@@ -19,29 +19,76 @@
 
 
 /*
- * Flavors
+ *  Flavors
  */
 
 #define ARM_THREAD_STATE		1
 #define ARM_VFP_STATE			2
 #define ARM_EXCEPTION_STATE		3
-#define ARM_DEBUG_STATE			4
+#define ARM_DEBUG_STATE			4 /* pre-armv8 */
 #define THREAD_STATE_NONE		5
+#define ARM_THREAD_STATE64		6
+#define ARM_EXCEPTION_STATE64	7
+
+/* ARM64_TODO: ref. ARM_SAVED_STATE64.  Separate these namespaces!  */
+
+#ifdef XNU_KERNEL_PRIVATE
+#define THREAD_STATE_LAST		8
+#endif
+
+/* For kernel use */
+#define ARM_SAVED_STATE32		(THREAD_STATE_LAST+1)
+#define ARM_SAVED_STATE64		(THREAD_STATE_LAST+2)
+#define ARM_NEON_SAVED_STATE32		(THREAD_STATE_LAST+3)
+#define ARM_NEON_SAVED_STATE64		(THREAD_STATE_LAST+4)
+/* ARM_VFP_STATE64			(THREAD_STATE_LAST+5)  */
+/* API */
+#define ARM_DEBUG_STATE32		(THREAD_STATE_LAST+6)
+#define ARM_DEBUG_STATE64		(THREAD_STATE_LAST+7)
+#define ARM_NEON_STATE64		(THREAD_STATE_LAST+9)
 
 #define VALID_THREAD_STATE_FLAVOR(x)\
 ((x == ARM_THREAD_STATE) 		||	\
  (x == ARM_VFP_STATE) 			||	\
  (x == ARM_EXCEPTION_STATE) 	||	\
  (x == ARM_DEBUG_STATE) 		||	\
- (x == THREAD_STATE_NONE))
+ (x == THREAD_STATE_NONE)		||  \
+ (x == ARM_NEON_STATE)		||	\
+ (x == ARM_DEBUG_STATE32)	||	\
+ (x == ARM_THREAD_STATE64)		||	\
+ (x == ARM_EXCEPTION_STATE64)	||	\
+ (x == ARM_NEON_STATE64)		||	\
+ (x == ARM_DEBUG_STATE64))
 
 typedef _STRUCT_ARM_THREAD_STATE		arm_thread_state_t;
+typedef _STRUCT_ARM_THREAD_STATE64		arm_thread_state64_t;
 typedef _STRUCT_ARM_VFP_STATE			arm_vfp_state_t;
+typedef _STRUCT_ARM_NEON_STATE			arm_neon_state_t;
+typedef _STRUCT_ARM_NEON_STATE64		arm_neon_state64_t;
 typedef _STRUCT_ARM_EXCEPTION_STATE		arm_exception_state_t;
+typedef _STRUCT_ARM_EXCEPTION_STATE64	arm_exception_state64_t;
+
+#if defined(XNU_KERNEL_PRIVATE) && defined(__arm64__)
+/* See below for ARM64 kernel structure definition for arm_debug_state. */
+#else
+/*
+ * Otherwise not ARM64 kernel and we must preserve legacy ARM definitions of
+ * arm_debug_state for binary compatability of userland consumers of this file.
+ */
+#if defined(__arm__)
 typedef _STRUCT_ARM_DEBUG_STATE			arm_debug_state_t;
+#elif defined(__arm64__)
+typedef _STRUCT_ARM_LEGACY_DEBUG_STATE		arm_debug_state_t;
+#else
+/* #error Undefined architecture */
+#endif
+#endif
 
 #define ARM_THREAD_STATE_COUNT ((mach_msg_type_number_t) \
    (sizeof (arm_thread_state_t)/sizeof(uint32_t)))
+
+#define ARM_THREAD_STATE64_COUNT ((mach_msg_type_number_t) \
+   (sizeof (arm_thread_state64_t)/sizeof(uint32_t)))
 
 #define ARM_VFP_STATE_COUNT ((mach_msg_type_number_t) \
    (sizeof (arm_vfp_state_t)/sizeof(uint32_t)))
@@ -49,13 +96,439 @@ typedef _STRUCT_ARM_DEBUG_STATE			arm_debug_state_t;
 #define ARM_EXCEPTION_STATE_COUNT ((mach_msg_type_number_t) \
    (sizeof (arm_exception_state_t)/sizeof(uint32_t)))
 
+#define ARM_EXCEPTION_STATE64_COUNT ((mach_msg_type_number_t) \
+   (sizeof (arm_exception_state64_t)/sizeof(uint32_t)))
+
 #define ARM_DEBUG_STATE_COUNT ((mach_msg_type_number_t) \
    (sizeof (arm_debug_state_t)/sizeof(uint32_t)))
+
+#define MACHINE_THREAD_STATE ARM_THREAD_STATE64
+#define MACHINE_THREAD_STATE_COUNT  ARM_THREAD_STATE_COUNT64
 
 /*
  * Largest state on this machine:
  */
 #define THREAD_MACHINE_STATE_MAX	THREAD_STATE_MAX
 
+#ifdef XNU_KERNEL_PRIVATE
+
+#if defined(__arm__)
+
+#define ARM_SAVED_STATE			THREAD_STATE_NONE + 1
+
+struct arm_saved_state {
+    uint32_t    r[13];      /* General purpose register r0-r12 */
+    uint32_t    sp;     /* Stack pointer r13 */
+    uint32_t    lr;     /* Link register r14 */
+    uint32_t    pc;     /* Program counter r15 */
+    uint32_t    cpsr;       /* Current program status register */
+    uint32_t    fsr;        /* Fault status */
+    uint32_t    far;        /* Virtual Fault Address */
+    uint32_t    exception;  /* exception number */
+};
+typedef struct arm_saved_state arm_saved_state_t;
+
+#ifdef XNU_KERNEL_PRIVATE
+typedef struct arm_saved_state arm_saved_state32_t;
+
+/*
+ * Just for coexistence with AArch64 code.
+ */
+static inline arm_saved_state32_t*
+saved_state32(arm_saved_state_t *iss)
+{
+    return iss;
+}
+
+static inline boolean_t
+is_saved_state32(arm_saved_state_t *iss __unused)
+{
+    return TRUE;
+}
+
+#endif
+
+struct arm_saved_state_tagged {
+	uint32_t					tag;
+	struct arm_saved_state		state;
+};
+typedef struct arm_saved_state_tagged arm_saved_state_tagged_t;
+
+#define ARM_SAVED_STATE32_COUNT ((mach_msg_type_number_t) \
+		(sizeof (arm_saved_state_t)/sizeof(unsigned int)))
+
+#elif defined(__arm64__)
+
+#include <kern/assert.h>
+#include <arm64/proc_reg.h>
+#define CAST_ASSERT_SAFE(type, val) (assert((val) == ((type)(val))), (type)(val))
+
+/*
+ * GPR context
+ */
+
+
+struct arm_saved_state32 {
+	uint32_t	r[13];		/* General purpose register r0-r12 */
+	uint32_t	sp;			/* Stack pointer r13 */
+	uint32_t	lr;			/* Link register r14 */
+	uint32_t	pc;			/* Program counter r15 */
+	uint32_t	cpsr;		/* Current program status register */
+	uint32_t	far;		/* Virtual fault address */
+	uint32_t	esr;		/* Exception syndrome register */
+	uint32_t	exception;	/* Exception number */
+};
+typedef struct arm_saved_state32 arm_saved_state32_t;
+
+struct arm_saved_state32_tagged {
+	uint32_t					tag;
+	struct arm_saved_state32	state;
+};
+typedef struct arm_saved_state32_tagged arm_saved_state32_tagged_t;
+
+#define ARM_SAVED_STATE32_COUNT ((mach_msg_type_number_t) \
+		(sizeof (arm_saved_state32_t)/sizeof(unsigned int)))
+
+struct arm_saved_state64 {
+	uint64_t    x[29];		/* General purpose registers x0-x28 */
+	uint64_t    fp;			/* Frame pointer x29 */
+	uint64_t    lr;			/* Link register x30 */
+	uint64_t    sp;			/* Stack pointer x31 */
+	uint64_t    pc;			/* Program counter */
+	uint32_t    cpsr;		/* Current program status register */
+	uint32_t	reserved;	/* Reserved padding */
+	uint64_t	far;		/* Virtual fault address */
+	uint32_t	esr;		/* Exception syndrome register */
+	uint32_t	exception;	/* Exception number */
+};
+typedef struct arm_saved_state64 arm_saved_state64_t;
+
+#define ARM_SAVED_STATE64_COUNT ((mach_msg_type_number_t) \
+		(sizeof (arm_saved_state64_t)/sizeof(unsigned int)))
+
+struct arm_saved_state64_tagged {
+	uint32_t					tag;
+	struct arm_saved_state64	state;
+};
+typedef struct arm_saved_state64_tagged arm_saved_state64_tagged_t;
+
+struct arm_saved_state {
+	uint32_t	flavor;
+	union {
+		struct arm_saved_state32 ss_32;
+		struct arm_saved_state64 ss_64;
+	} uss;
+} __attribute__((aligned(16)));
+#define	ss_32	uss.ss_32
+#define	ss_64	uss.ss_64
+
+typedef struct arm_saved_state arm_saved_state_t;
+
+
+static inline boolean_t
+is_saved_state32(arm_saved_state_t *iss)
+{
+	return (iss->flavor == ARM_SAVED_STATE32);
+}
+
+static inline boolean_t
+is_saved_state64(arm_saved_state_t *iss)
+{
+	return (iss->flavor == ARM_SAVED_STATE64);
+}
+
+static inline arm_saved_state32_t*
+saved_state32(arm_saved_state_t *iss)
+{
+	return &iss->ss_32;
+}
+
+static inline arm_saved_state64_t*
+saved_state64(arm_saved_state_t *iss)
+{
+	return &iss->ss_64;
+}
+
+static inline register_t
+get_saved_state_pc(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->pc : saved_state64(iss)->pc);
+}
+
+static inline void
+set_saved_state_pc(arm_saved_state_t *iss, register_t pc)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->pc = CAST_ASSERT_SAFE(uint32_t, pc);
+	} else {
+		saved_state64(iss)->pc = pc;
+	}
+}
+
+static inline register_t
+get_saved_state_sp(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->sp : saved_state64(iss)->sp);
+}
+
+static inline void
+set_saved_state_sp(arm_saved_state_t *iss, register_t sp)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->sp = CAST_ASSERT_SAFE(uint32_t, sp);
+	} else {
+		saved_state64(iss)->sp = sp;
+	}
+}
+
+static inline register_t
+get_saved_state_lr(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->lr : saved_state64(iss)->lr);
+}
+
+static inline void
+set_saved_state_lr(arm_saved_state_t *iss, register_t lr)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->lr = CAST_ASSERT_SAFE(uint32_t, lr);
+	} else {
+		saved_state64(iss)->lr = lr;
+	}
+}
+
+static inline register_t
+get_saved_state_fp(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->r[7] : saved_state64(iss)->fp);
+}
+
+static inline void
+set_saved_state_fp(arm_saved_state_t *iss, register_t fp)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->r[7] = CAST_ASSERT_SAFE(uint32_t, fp);
+	} else {
+		saved_state64(iss)->fp = fp;
+	}
+}
+
+static inline int
+check_saved_state_reglimit(arm_saved_state_t *iss, unsigned reg) 
+{
+	return (is_saved_state32(iss) ? (reg < ARM_SAVED_STATE32_COUNT) : (reg < ARM_SAVED_STATE64_COUNT));
+}
+
+static inline register_t
+get_saved_state_reg(arm_saved_state_t *iss, unsigned reg)
+{
+	if (!check_saved_state_reglimit(iss, reg)) return 0;
+
+	return (is_saved_state32(iss) ? (saved_state32(iss)->r[reg]) : (saved_state64(iss)->x[reg]));
+}
+
+static inline void
+set_saved_state_reg(arm_saved_state_t *iss, unsigned reg, register_t value)
+{
+	if (!check_saved_state_reglimit(iss, reg)) return;
+
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->r[reg] = CAST_ASSERT_SAFE(uint32_t, value);
+	} else {
+		saved_state64(iss)->x[reg] = value;
+	}
+}
+
+static inline uint32_t
+get_saved_state_cpsr(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->cpsr : saved_state64(iss)->cpsr);
+}
+
+static inline void
+set_saved_state_cpsr(arm_saved_state_t *iss, uint32_t cpsr)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->cpsr = cpsr;
+	} else {
+		saved_state64(iss)->cpsr = cpsr;
+	}
+}
+
+static inline register_t
+get_saved_state_far(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->far : saved_state64(iss)->far);
+}
+
+static inline void
+set_saved_state_far(arm_saved_state_t *iss, register_t far)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->far = CAST_ASSERT_SAFE(uint32_t, far);
+	} else {
+		saved_state64(iss)->far = far;
+	}
+}
+
+static inline uint32_t
+get_saved_state_esr(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->esr : saved_state64(iss)->esr);
+}
+
+static inline void
+set_saved_state_esr(arm_saved_state_t *iss, uint32_t esr)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->esr = esr;
+	} else {
+		saved_state64(iss)->esr = esr;
+	}
+}
+
+static inline uint32_t
+get_saved_state_exc(arm_saved_state_t *iss)
+{
+	return (is_saved_state32(iss) ? saved_state32(iss)->exception : saved_state64(iss)->exception);
+}
+
+static inline void
+set_saved_state_exc(arm_saved_state_t *iss, uint32_t exc)
+{
+	if (is_saved_state32(iss)) {
+		saved_state32(iss)->exception = exc;
+	} else {
+		saved_state64(iss)->exception = exc;
+	}
+}
+
+/*
+ * ARM64_TODO: what register holds syscall number?
+ */
+extern void panic_unimplemented(void);
+
+static inline int
+get_saved_state_svc_number(arm_saved_state_t *iss) 
+{
+	return (is_saved_state32(iss) ? (int)saved_state32(iss)->r[12] : (int)saved_state64(iss)->x[ARM64_SYSCALL_CODE_REG_NUM]); /* Only first word counts here */
+}
+
+
+typedef _STRUCT_ARM_LEGACY_DEBUG_STATE		arm_legacy_debug_state_t;
+typedef _STRUCT_ARM_DEBUG_STATE32		arm_debug_state32_t;
+typedef _STRUCT_ARM_DEBUG_STATE64		arm_debug_state64_t;
+
+struct arm_state_hdr {
+    int flavor;
+    int count;
+};
+typedef struct arm_state_hdr arm_state_hdr_t;
+
+struct arm_debug_aggregate_state {
+    arm_state_hdr_t         dsh;
+    union {
+        arm_debug_state32_t ds32;
+        arm_debug_state64_t ds64;
+    } uds;
+} __attribute__((aligned(16)));
+
+typedef struct arm_debug_aggregate_state arm_debug_state_t;
+
+#define ARM_LEGACY_DEBUG_STATE_COUNT ((mach_msg_type_number_t) \
+   (sizeof (arm_legacy_debug_state_t)/sizeof(uint32_t)))
+
+#define ARM_DEBUG_STATE32_COUNT ((mach_msg_type_number_t) \
+   (sizeof (arm_debug_state32_t)/sizeof(uint32_t)))
+
+#define ARM_DEBUG_STATE64_COUNT ((mach_msg_type_number_t) \
+   (sizeof (arm_debug_state64_t)/sizeof(uint32_t)))
+
+/*
+ * NEON context
+ */
+typedef __uint128_t uint128_t;
+typedef uint64_t uint64x2_t __attribute__((ext_vector_type(2)));
+typedef uint32_t uint32x4_t __attribute__((ext_vector_type(4)));
+
+struct arm_neon_saved_state32 {
+	union {
+		uint128_t	q[16];
+		uint64_t	d[32];
+		uint32_t	s[32];
+	} v;
+	uint32_t		fpsr;
+	uint32_t		fpcr;
+};
+typedef struct arm_neon_saved_state32 arm_neon_saved_state32_t;
+
+struct arm_neon_saved_state64 {
+	union {
+		uint128_t		q[32];
+		uint64x2_t		d[32];
+		uint32x4_t		s[32];
+	} v;
+	uint32_t		fpsr;
+	uint32_t		fpcr;
+};
+typedef struct arm_neon_saved_state64 arm_neon_saved_state64_t;
+
+
+#define ARM_NEON_STATE_COUNT ((mach_msg_type_number_t) \
+   (sizeof (arm_neon_state_t)/sizeof(uint32_t)))
+#define ARM_NEON_STATE64_COUNT ((mach_msg_type_number_t) \
+   (sizeof (arm_neon_state64_t)/sizeof(uint32_t)))
+
+struct arm_neon_saved_state {
+	uint32_t flavor;
+	union {
+		struct arm_neon_saved_state32 ns_32;
+		struct arm_neon_saved_state64 ns_64;
+	} uns;
+};
+typedef struct arm_neon_saved_state arm_neon_saved_state_t;
+#define	ns_32	uns.ns_32
+#define	ns_64	uns.ns_64
+
+static inline boolean_t
+is_neon_saved_state32(arm_neon_saved_state_t *state)
+{
+	return (state->flavor == ARM_NEON_SAVED_STATE32);
+}
+
+static inline boolean_t
+is_neon_saved_state64(arm_neon_saved_state_t *state)
+{
+	return (state->flavor == ARM_NEON_SAVED_STATE64);
+}
+
+static inline arm_neon_saved_state32_t *
+neon_state32(arm_neon_saved_state_t *state)
+{
+	return &state->ns_32;
+}
+
+static inline arm_neon_saved_state64_t *
+neon_state64(arm_neon_saved_state_t *state)
+{
+	return &state->ns_64;
+}
+
+
+/*
+ * Aggregated context
+ */
+
+struct arm_context {
+	struct arm_saved_state ss;
+	struct arm_neon_saved_state ns;
+};
+typedef struct arm_context arm_context_t;
+
+#else
+#error Unknown arch
+#endif
+
+#endif /* XNU_KERNEL_PRIVATE */
 
 #endif    /* _ARM_THREAD_STATUS_H_ */

--- a/include/mach/machine.h
+++ b/include/mach/machine.h
@@ -159,6 +159,8 @@ extern vm_offset_t		interrupt_stack[];
 #define CPU_ARCH_ABI64		 0x1000000
 #define CPU_TYPE_POWERPC64	((cpu_type_t)(CPU_TYPE_POWERPC | CPU_ARCH_ABI64))
 #define CPU_TYPE_VEO		((cpu_type_t) 255)
+#define CPU_TYPE_ARM64		((cpu_type_t)(CPU_TYPE_ARM | CPU_ARCH_ABI64))
+		
 
 /*
  *	Machine subtypes (these are defined here, instead of in a machine
@@ -249,6 +251,7 @@ extern vm_offset_t		interrupt_stack[];
 #define CPU_SUBTYPE_INTEL_MODEL(x)	((x) >> 4)
 #define CPU_SUBTYPE_INTEL_MODEL_ALL	0
 
+#define CPU_SUBTYPE_X86_64_H	((cpu_subtype_t)8) /* Haswell and compatible */
 
 /*
  *	Mips subtypes.
@@ -307,7 +310,15 @@ extern vm_offset_t		interrupt_stack[];
 #define CPU_SUBTYPE_ARM_XSCALE		((cpu_subtype_t) 8)
 #define CPU_SUBTYPE_ARM_V7		((cpu_subtype_t) 9)
 #define CPU_SUBTYPE_ARM_V7F		((cpu_subtype_t) 10) /* Cortex A9 */
-#define CPU_SUBTYPE_ARM_V7K		((cpu_subtype_t) 12)
+#define CPU_SUBTYPE_ARM_V7S		((cpu_subtype_t) 11) /* Swift */
+#define CPU_SUBTYPE_ARM_V7K		((cpu_subtype_t) 12) /* Kirkwood40 */
+#define CPU_SUBTYPE_ARM_V6M		((cpu_subtype_t) 14) /* Not meant to be run under xnu */
+#define CPU_SUBTYPE_ARM_V7M		((cpu_subtype_t) 15) /* Not meant to be run under xnu */
+#define CPU_SUBTYPE_ARM_V7EM		((cpu_subtype_t) 16) /* Not meant to be run under xnu */
+#define CPU_SUBTYPE_ARM_V8		((cpu_subtype_t) 13)
+
+#define	CPU_SUBTYPE_ARM64_ALL		((cpu_subtype_t) 0)
+#define	CPU_SUBTYPE_ARM64_V8		((cpu_subtype_t) 1)
 
 /*
  *	MC88000 subtypes
@@ -384,5 +395,6 @@ extern vm_offset_t		interrupt_stack[];
 #define CPU_SUBTYPE_VEO_3	((cpu_subtype_t) 3)
 #define CPU_SUBTYPE_VEO_4	((cpu_subtype_t) 4)
 #define CPU_SUBTYPE_VEO_ALL	CPU_SUBTYPE_VEO_2
+
 
 #endif	/* _MACH_MACHINE_H_ */

--- a/include/stuff/breakout.h
+++ b/include/stuff/breakout.h
@@ -48,8 +48,8 @@ struct toc_entry {
 struct arch {
     char *file_name;		/* name of file this arch came from */
     enum ofile_type type;	/* The type of file for this architecture */
-				/*  can be OFILE_ARCHIVE, OFILE_Mach_O or */
-    				/*  OFILE_UNKNOWN. */
+				/*  can be OFILE_ARCHIVE, OFILE_Mach_O, */
+    				/*  OFILE_LLVM_BITCODE or OFILE_UNKNOWN. */
     struct fat_arch *fat_arch;	/* If this came from fat file this is valid */
 			        /*  and not NULL (needed for the align value */
 				/*  and to output a fat file if only one arch)*/
@@ -84,6 +84,11 @@ struct arch {
     /* if this is an object file: the object file */
     struct object *object;	/* the object file */
 
+#ifdef LTO_SUPPORT
+    /* if this member is an llvm bit code file: the lto module */
+    void *lto;                  /* lto module */
+#endif /* LTO_SUPPORT */
+
     /* if this is an unknown file: the addr and size of the file */
     char *unknown_addr;
     uint32_t unknown_size;
@@ -94,7 +99,7 @@ struct arch {
 
 struct member {
     enum ofile_type type;	/* the type of this member can be OFILE_Mach_O*/
-				/*  or OFILE_UNKNOWN */
+				/*  OFILE_LLVM_BITCODE or OFILE_UNKNOWN */
     struct ar_hdr *ar_hdr;	/* the archive header for this member */
     uint32_t offset;		/* current working offset and final offset */
 				/*  use in creating the table of contents */
@@ -107,6 +112,11 @@ struct member {
 
     /* if this member is an object file: the object file */
     struct object *object;	/* the object file */
+
+#ifdef LTO_SUPPORT
+    /* if this member is an llvm bit code file: the lto module */
+    void *lto;                  /* lto module */
+#endif /* LTO_SUPPORT */
 
     /* if this member is an unknown file: the addr and size of the member */
     char *unknown_addr;
@@ -152,6 +162,9 @@ struct object {
 	*data_in_code_cmd;	    /* the data in code load command, if any */
     struct linkedit_data_command
 	*code_sign_drs_cmd;	    /* the code signing DRs command, if any */
+    struct linkedit_data_command
+	*link_opt_hint_cmd;	    /* the linker optimization hint command,
+				       if any */
     struct section **sections;	    /* array of 32-bit section structs */
     struct section_64 **sections64; /* array of 64-bit section structs */
     struct dyld_info_command
@@ -200,6 +213,8 @@ struct object {
     uint32_t      output_data_in_code_info_data_size;
     char *output_code_sign_drs_info_data;
     uint32_t      output_code_sign_drs_info_data_size;
+    char *output_link_opt_hint_info_data;
+    uint32_t      output_link_opt_hint_info_data_size;
 
     uint32_t      output_ilocalsym;
     uint32_t      output_nlocalsym;

--- a/include/stuff/bytesex.h
+++ b/include/stuff/bytesex.h
@@ -50,10 +50,6 @@
 #include <mach/i386/thread_status.h>
 #include <mach/hppa/thread_status.h>
 #include <mach/sparc/thread_status.h>
-#undef MACHINE_THREAD_STATE	/* need to undef these to avoid warnings */
-#undef MACHINE_THREAD_STATE_COUNT
-#undef THREAD_STATE_NONE
-#undef VALID_THREAD_STATE_FLAVOR
 #include <mach/arm/thread_status.h>
 #include <mach-o/nlist.h>
 #include <mach-o/reloc.h>
@@ -311,6 +307,10 @@ __private_extern__ void swap_arm_thread_state_t(
     arm_thread_state_t *cpu,
     enum byte_sex target_byte_sex);
 
+__private_extern__ void swap_arm_thread_state64_t(
+    arm_thread_state64_t *cpu,
+    enum byte_sex target_byte_sex);
+
 __private_extern__ void swap_ident_command(
     struct ident_command *id_cmd,
     enum byte_sex target_byte_sex);
@@ -349,6 +349,14 @@ __private_extern__ void swap_rpath_command(
 
 __private_extern__ void swap_encryption_command(
     struct encryption_info_command *ec,
+    enum byte_sex target_byte_sex);
+
+__private_extern__ void swap_encryption_command_64(
+    struct encryption_info_command_64 *ec,
+    enum byte_sex target_byte_sex);
+
+__private_extern__ void swap_linker_option_command(
+    struct linker_option_command *lo,
     enum byte_sex target_byte_sex);
 
 __private_extern__ void swap_dyld_info_command(
@@ -411,6 +419,11 @@ __private_extern__ void swap_dylib_table_of_contents(
 __private_extern__ void swap_twolevel_hint(
     struct twolevel_hint *hints,
     uint32_t nhints,
+    enum byte_sex target_byte_sex);
+
+__private_extern__ void swap_data_in_code_entry(
+    struct data_in_code_entry *dices,
+    uint32_t ndices,
     enum byte_sex target_byte_sex);
 
 /*

--- a/include/stuff/errors.h
+++ b/include/stuff/errors.h
@@ -25,67 +25,63 @@
  * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#if defined(__MWERKS__) && !defined(__private_extern__)
-#define __private_extern__ __declspec(private_extern)
-#endif
-
 #import "mach/mach.h"
 
 /* user defined (imported) */
-__private_extern__ char *progname;
+extern char *progname __attribute__((visibility("hidden")));
 
 /* defined in errors.c */
 /* number of detected calls to error() */
-__private_extern__ uint32_t errors;
+extern uint32_t errors __attribute__((visibility("hidden")));
 
-__private_extern__ void warning(
+extern void warning(
     const char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 1, 2)))
 #endif
-    ;
-__private_extern__ void error(
+    __attribute__((visibility("hidden")));
+extern void error(
     const char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 1, 2)))
 #endif
-    ;
-__private_extern__ void error_with_arch(
+    __attribute__((visibility("hidden")));
+extern void error_with_arch(
     const char *arch_name,
     const char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 2, 3)))
 #endif
-    ;
-__private_extern__ void system_error(
+    __attribute__((visibility("hidden")));
+extern void system_error(
     const char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 1, 2)))
 #endif
-    ;
-__private_extern__ void fatal(
+    __attribute__((visibility("hidden")));
+extern void fatal(
     const char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 1, 2)))
 #endif
-    ;
-__private_extern__ void system_fatal(
+    __attribute__((visibility("hidden")));
+extern void system_fatal(
     const char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 1, 2)))
 #endif
-    ;
-__private_extern__ void my_mach_error(
+    __attribute__((visibility("hidden")));
+extern void my_mach_error(
     kern_return_t r,
     char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 2, 3)))
 #endif
-    ;
-__private_extern__ void mach_fatal(
+    __attribute__((visibility("hidden")));
+extern void mach_fatal(
     kern_return_t r,
     char *format, ...)
 #ifdef __GNUC__
     __attribute__ ((format (printf, 2, 3)))
 #endif
-    ;
+    __attribute__((visibility("hidden")));

--- a/include/stuff/ofile.h
+++ b/include/stuff/ofile.h
@@ -57,7 +57,7 @@ enum ofile_type {
 struct ofile {
     char *file_name;		    /* pointer to name malloc'ed by ofile_map */
     char *file_addr;		    /* pointer to vm_allocate'ed memory       */
-    uint32_t file_size;	    	    /* size of vm_allocate'ed memory	      */
+    uint64_t file_size;	    	    /* size of vm_allocate'ed memory	      */
     uint64_t file_mtime;	    /* stat(2)'s mtime                        */
     enum ofile_type file_type;	    /* type of the file			      */
 
@@ -159,7 +159,7 @@ __private_extern__ NSObjectFileImageReturnCode ofile_map_from_memory(
 __private_extern__ enum bool ofile_map_from_memory(
 #endif
     char *addr,
-    uint32_t size,
+    uint64_t size,
     const char *file_name,
     uint64_t mtime,
     const struct arch_flag *arch_flag,	/* can be NULL */

--- a/install_name_tool.c
+++ b/install_name_tool.c
@@ -595,6 +595,16 @@ struct object *object)
 		object->output_sym_info_size +=
 		    object->code_sign_drs_cmd->datasize;
 	    }
+	    if(object->link_opt_hint_cmd != NULL){
+		object->output_link_opt_hint_info_data = 
+		(object->object_addr + object->link_opt_hint_cmd->dataoff);
+		object->output_link_opt_hint_info_data_size = 
+		    object->link_opt_hint_cmd->datasize;
+		object->input_sym_info_size +=
+		    object->link_opt_hint_cmd->datasize;
+		object->output_sym_info_size +=
+		    object->link_opt_hint_cmd->datasize;
+	    }
 	    if(object->hints_cmd != NULL){
 		object->output_hints = (struct twolevel_hint *)
 		    (object->object_addr +
@@ -978,6 +988,7 @@ uint32_t *header_size)
 	    rpath2->path.offset = sizeof(struct rpath_command);
 	    path2 = (char *)rpath2 + rpath2->path.offset;
 	    strcpy(path2, add_rpaths[i].new);
+	    lc2 = (struct load_command *)((char *)lc2 + lc2->cmdsize);
 	}
 	ncmds += nadd_rpaths;
 	ncmds -= ndelete_rpaths;
@@ -1059,6 +1070,10 @@ uint32_t *header_size)
 		break;
 	    case LC_DYLIB_CODE_SIGN_DRS:
 		arch->object->code_sign_drs_cmd =
+		    (struct linkedit_data_command *)lc1;
+		break;
+	    case LC_LINKER_OPTIMIZATION_HINT:
+		arch->object->link_opt_hint_cmd =
 		    (struct linkedit_data_command *)lc1;
 		break;
 	    }

--- a/libstuff/arch.c
+++ b/libstuff/arch.c
@@ -48,6 +48,8 @@ static const struct arch_flag arch_flags[] = {
     /* architecture families */
     { "ppc64",     CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_ALL },
     { "x86_64",    CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_ALL },
+    { "x86_64h",   CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_H },
+    { "arm64",     CPU_TYPE_ARM64,     CPU_SUBTYPE_ARM64_ALL },
     /* specific architecture implementations */
     { "ppc970-64", CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_970 },
 
@@ -94,9 +96,14 @@ static const struct arch_flag arch_flags[] = {
     { "armv5",  CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V5TEJ},
     { "xscale", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_XSCALE},
     { "armv6",  CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V6 },
+    { "armv6m", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V6M },
     { "armv7",  CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7 },
     { "armv7f", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7F },
+    { "armv7s", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7S },
     { "armv7k", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7K },
+    { "armv7m", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7M },
+    { "armv7em", CPU_TYPE_ARM,    CPU_SUBTYPE_ARM_V7EM },
+    { "arm64v8",CPU_TYPE_ARM64,   CPU_SUBTYPE_ARM64_V8 },
     { NULL,	0,		  0 }
 };
 
@@ -214,6 +221,7 @@ const struct arch_flag *flag)
         return BIG_ENDIAN_BYTE_SEX;
     else if(flag->cputype == CPU_TYPE_I386 ||
 	    flag->cputype == CPU_TYPE_X86_64 ||
+	    flag->cputype == CPU_TYPE_ARM64 ||
 	    flag->cputype == CPU_TYPE_ARM)
         return LITTLE_ENDIAN_BYTE_SEX;
     else

--- a/libstuff/bytesex.c
+++ b/libstuff/bytesex.c
@@ -200,10 +200,6 @@
 #include <mach/i386/thread_status.h>
 #include <mach/hppa/thread_status.h>
 #include <mach/sparc/thread_status.h>
-#undef MACHINE_THREAD_STATE	/* need to undef these to avoid warnings */
-#undef MACHINE_THREAD_STATE_COUNT
-#undef THREAD_STATE_NONE
-#undef VALID_THREAD_STATE_FLAVOR
 #include <mach/arm/thread_status.h>
 #include <mach-o/nlist.h>
 #include <mach-o/reloc.h>
@@ -2349,6 +2345,22 @@ enum byte_sex target_byte_sex)
 	cpu->__cpsr = SWAP_INT(cpu->__cpsr);
 }
 
+void
+swap_arm_thread_state64_t(
+arm_thread_state64_t *cpu,
+enum byte_sex target_byte_sex)
+{
+    int i;
+
+	for(i = 0; i < 29; i++)
+	    cpu->__x[i] = SWAP_LONG_LONG(cpu->__x[i]);
+	cpu->__fp = SWAP_LONG_LONG(cpu->__fp);
+	cpu->__lr = SWAP_LONG_LONG(cpu->__lr);
+	cpu->__sp = SWAP_LONG_LONG(cpu->__sp);
+	cpu->__pc = SWAP_LONG_LONG(cpu->__pc);
+	cpu->__cpsr = SWAP_INT(cpu->__cpsr);
+}
+
 __private_extern__
 void
 swap_ident_command(
@@ -2464,6 +2476,22 @@ enum byte_sex target_byte_sex)
 
 __private_extern__
 void
+swap_data_in_code_entry(
+struct data_in_code_entry *dices,
+uint32_t ndices,
+enum byte_sex target_byte_sex)
+{
+    uint32_t i;
+
+	for(i = 0; i < ndices; i++){
+	    dices[i].offset = SWAP_INT(dices[i].offset);
+	    dices[i].length = SWAP_INT(dices[i].length);
+	    dices[i].kind = SWAP_INT(dices[i].kind);
+	}
+}
+
+__private_extern__
+void
 swap_prebind_cksum_command(
 struct prebind_cksum_command *cksum_cmd,
 enum byte_sex target_byte_sex)
@@ -2531,6 +2559,31 @@ enum byte_sex target_byte_sex)
 	ec->cryptoff = SWAP_INT(ec->cryptoff);
 	ec->cryptsize = SWAP_INT(ec->cryptsize);
 	ec->cryptid = SWAP_INT(ec->cryptid);
+}
+
+__private_extern__
+ void
+swap_encryption_command_64(
+struct encryption_info_command_64 *ec,
+enum byte_sex target_byte_sex)
+{
+	ec->cmd = SWAP_INT(ec->cmd);
+	ec->cmdsize = SWAP_INT(ec->cmdsize);
+	ec->cryptoff = SWAP_INT(ec->cryptoff);
+	ec->cryptsize = SWAP_INT(ec->cryptsize);
+	ec->cryptid = SWAP_INT(ec->cryptid);
+	ec->cryptid = SWAP_INT(ec->pad);
+}
+
+__private_extern__
+ void
+swap_linker_option_command(
+struct linker_option_command *lo,
+enum byte_sex target_byte_sex)
+{
+	lo->cmd = SWAP_INT(lo->cmd);
+	lo->cmdsize = SWAP_INT(lo->cmdsize);
+	lo->count = SWAP_INT(lo->count);
 }
 
 __private_extern__

--- a/libstuff/checkout.c
+++ b/libstuff/checkout.c
@@ -155,6 +155,13 @@ struct object *object)
 		object->code_sign_drs_cmd =
 			(struct linkedit_data_command *)lc;
 	    }
+	    else if(lc->cmd == LC_LINKER_OPTIMIZATION_HINT){
+		if(object->link_opt_hint_cmd != NULL)
+		    fatal_arch(arch, member, "malformed file (more than one "
+			"LC_LINKER_OPTIMIZATION_HINT load command): ");
+		object->link_opt_hint_cmd =
+			(struct linkedit_data_command *)lc;
+	    }
 	    else if((lc->cmd == LC_DYLD_INFO) ||(lc->cmd == LC_DYLD_INFO_ONLY)){
 		if(object->dyld_info != NULL)
 		    fatal_arch(arch, member, "malformed file (more than one "
@@ -393,6 +400,12 @@ struct object *object)
 	    if(object->code_sign_drs_cmd->dataoff != offset)
 		order_error(arch, member, "code signing DRs info out of place");
 	    offset += object->code_sign_drs_cmd->datasize;
+	}
+	if(object->link_opt_hint_cmd != NULL){
+	    if(object->link_opt_hint_cmd->dataoff != offset)
+		order_error(arch, member, "linker optimization hint info out "
+					  "of place");
+	    offset += object->link_opt_hint_cmd->datasize;
 	}
 	if(object->st->nsyms != 0){
 	    if(object->st->symoff != offset)

--- a/libstuff/errors.c
+++ b/libstuff/errors.c
@@ -45,7 +45,7 @@ const char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "warning: %s: ", progname);
 	vfprintf(stderr, format, ap);
         fprintf(stderr, "\n");
 	va_end(ap);
@@ -64,7 +64,7 @@ const char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "error: %s: ", progname);
 	vfprintf(stderr, format, ap);
         fprintf(stderr, "\n");
 	va_end(ap);
@@ -85,7 +85,7 @@ const char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "error: %s: ", progname);
 	if(arch_name != NULL)
 	    fprintf(stderr, "for architecture: %s ", arch_name);
 	vfprintf(stderr, format, ap);
@@ -107,7 +107,7 @@ const char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "error: %s: ", progname);
 	vfprintf(stderr, format, ap);
 	fprintf(stderr, " (%s)\n", strerror(errno));
 	va_end(ap);
@@ -127,7 +127,7 @@ char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "error: %s: ", progname);
 	vfprintf(stderr, format, ap);
 	fprintf(stderr, " (%s)\n", mach_error_string(r));
 	va_end(ap);

--- a/libstuff/execute.c
+++ b/libstuff/execute.c
@@ -149,7 +149,7 @@ char *str)
 	int i;
 	char *p;
 	char *prefix, buf[MAXPATHLEN], resolved_name[PATH_MAX];
-	unsigned long bufsize;
+	uint32_t bufsize;
 
 	/*
 	 * Construct the prefix to the program running.

--- a/libstuff/fatals.c
+++ b/libstuff/fatals.c
@@ -43,7 +43,7 @@ const char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "fatal error: %s: ", progname);
 	vfprintf(stderr, format, ap);
         fprintf(stderr, "\n");
 	va_end(ap);
@@ -62,7 +62,7 @@ const char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "fatal error: %s: ", progname);
 	vfprintf(stderr, format, ap);
 	fprintf(stderr, " (%s)\n", strerror(errno));
 	va_end(ap);
@@ -82,7 +82,7 @@ char *format,
     va_list ap;
 
 	va_start(ap, format);
-        fprintf(stderr, "%s: ", progname);
+        fprintf(stderr, "fatal error: %s: ", progname);
 	vfprintf(stderr, format, ap);
 	fprintf(stderr, " (%s)\n", mach_error_string(r));
 	va_end(ap);

--- a/libstuff/get_arch_from_host.c
+++ b/libstuff/get_arch_from_host.c
@@ -439,6 +439,14 @@ struct arch_flag *specific_arch_flag)
 		if(specific_arch_flag != NULL)
 		    specific_arch_flag->name = "armv6";
 		return(1);
+	    case CPU_SUBTYPE_ARM_V6M:
+		if(family_arch_flag != NULL){
+		    family_arch_flag->name = "arm";
+		    family_arch_flag->cpusubtype = CPU_SUBTYPE_ARM_ALL;
+		}
+		if(specific_arch_flag != NULL)
+		    specific_arch_flag->name = "armv6m";
+		return(1);
 	    case CPU_SUBTYPE_ARM_V7:
 		if(family_arch_flag != NULL){
 		    family_arch_flag->name = "arm";
@@ -455,6 +463,14 @@ struct arch_flag *specific_arch_flag)
 		if(specific_arch_flag != NULL)
 		    specific_arch_flag->name = "armv7f";
 		return(1);
+	    case CPU_SUBTYPE_ARM_V7S:
+		if(family_arch_flag != NULL){
+		    family_arch_flag->name = "arm";
+		    family_arch_flag->cpusubtype = CPU_SUBTYPE_ARM_ALL;
+		}
+		if(specific_arch_flag != NULL)
+		    specific_arch_flag->name = "armv7s";
+		return(1);
 	    case CPU_SUBTYPE_ARM_V7K:
 		if(family_arch_flag != NULL){
 		    family_arch_flag->name = "arm";
@@ -462,6 +478,42 @@ struct arch_flag *specific_arch_flag)
 		}
 		if(specific_arch_flag != NULL)
 		    specific_arch_flag->name = "armv7k";
+		return(1);
+	    case CPU_SUBTYPE_ARM_V7M:
+		if(family_arch_flag != NULL){
+		    family_arch_flag->name = "arm";
+		    family_arch_flag->cpusubtype = CPU_SUBTYPE_ARM_ALL;
+		}
+		if(specific_arch_flag != NULL)
+		    specific_arch_flag->name = "armv7m";
+		return(1);
+	    case CPU_SUBTYPE_ARM_V7EM:
+		if(family_arch_flag != NULL){
+		    family_arch_flag->name = "arm";
+		    family_arch_flag->cpusubtype = CPU_SUBTYPE_ARM_ALL;
+		}
+		if(specific_arch_flag != NULL)
+		    specific_arch_flag->name = "armv7em";
+		return(1);
+	    }
+	    break;
+	case CPU_TYPE_ARM64:
+	    switch(host_basic_info.cpu_subtype){
+	    case CPU_SUBTYPE_ARM64_ALL:
+		if(family_arch_flag != NULL){
+		    family_arch_flag->name = "arm64";
+		    family_arch_flag->cpusubtype = CPU_SUBTYPE_ARM64_ALL;
+		}
+		if(specific_arch_flag != NULL)
+		    specific_arch_flag->name = "arm64";
+		return(1);
+	    case CPU_SUBTYPE_ARM64_V8:
+		if(family_arch_flag != NULL){
+		    family_arch_flag->name = "arm64";
+		    family_arch_flag->cpusubtype = CPU_SUBTYPE_ARM64_ALL;
+		}
+		if(specific_arch_flag != NULL)
+		    specific_arch_flag->name = "arm64v8";
 		return(1);
 	    }
 	    break;

--- a/libstuff/lto.c
+++ b/libstuff/lto.c
@@ -77,7 +77,7 @@ struct arch_flag *arch_flag,
 void **pmod) /* maybe NULL */
 {
 
-   size_t bufsize;
+   uint32_t bufsize;
    char *p, *prefix, *lto_path, buf[MAXPATHLEN], resolved_name[PATH_MAX];
    int i;
    void *mod;
@@ -92,18 +92,11 @@ void **pmod) /* maybe NULL */
 	if(tried_to_load_lto == 0){
 	    tried_to_load_lto = 1;
 	    /*
-	     * The design is rather lame and inelegant: "llvm support is only
-	     * for stuff in /Developer and not the tools installed in /".
-	     * Which would mean tools like libtool(1) run from /usr/bin would
-	     * not work with lto, and work differently if the same binary was
-	     * installed in /Developer/usr/bin . And if the tools were
-	     * installed in some other location besides /Developer, like
-	     * /Developer/Platforms/...  that would also not work.
-	     *
-	     * So instead construct the prefix to this executable assuming it
-	     * is in a bin directory relative to a lib directory of the matching
-	     * lto library and first try to load that.  If not then fall back to
-	     * trying "/Developer/usr/lib/libLTO.dylib".
+	     * Construct the prefix to this executable assuming it is in a bin
+	     * directory relative to a lib directory of the matching lto library
+	     * and first try to load that.  If not then fall back to trying
+	     * "/Applications/Xcode.app/Contents/Developer/Toolchains/
+	     * XcodeDefault.xctoolchain/usr/lib/libLTO.dylib".
 	     */
 	    bufsize = MAXPATHLEN;
 	    p = buf;
@@ -122,7 +115,9 @@ void **pmod) /* maybe NULL */
 	    if(lto_handle == NULL){
 		free(lto_path);
 		lto_path = NULL;
-		lto_handle = dlopen("/Developer/usr/lib/libLTO.dylib",
+		lto_handle = dlopen("/Applications/Xcode.app/Contents/"
+				    "Developer/Toolchains/XcodeDefault."
+				    "xctoolchain/usr/lib/libLTO.dylib",
 				    RTLD_NOW);
 	    }
 	    if(lto_handle == NULL)
@@ -212,6 +207,10 @@ char *target_triple)
 	    arch_flag->cputype = CPU_TYPE_X86_64;
 	    arch_flag->cpusubtype = CPU_SUBTYPE_X86_64_ALL;
 	}
+	else if(strncmp(target_triple, "x86_64h", n) == 0){
+	    arch_flag->cputype = CPU_TYPE_X86_64;
+	    arch_flag->cpusubtype = CPU_SUBTYPE_X86_64_H;
+	}
 	else if(strncmp(target_triple, "powerpc", n) == 0){
 	    arch_flag->cputype = CPU_TYPE_POWERPC;
 	    arch_flag->cpusubtype = CPU_SUBTYPE_POWERPC_ALL;
@@ -236,6 +235,11 @@ char *target_triple)
 	    arch_flag->cputype = CPU_TYPE_ARM;
 	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V6;
 	}
+	else if(strncmp(target_triple, "armv6m", n) == 0 ||
+	        strncmp(target_triple, "thumbv6m", n) == 0){
+	    arch_flag->cputype = CPU_TYPE_ARM;
+	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V6M;
+	}
 	else if(strncmp(target_triple, "armv7", n) == 0 ||
 	        strncmp(target_triple, "thumbv7", n) == 0){
 	    arch_flag->cputype = CPU_TYPE_ARM;
@@ -246,10 +250,29 @@ char *target_triple)
 	    arch_flag->cputype = CPU_TYPE_ARM;
 	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V7F;
 	}
+	else if(strncmp(target_triple, "armv7s", n) == 0 ||
+	        strncmp(target_triple, "thumbv7s", n) == 0){
+	    arch_flag->cputype = CPU_TYPE_ARM;
+	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V7S;
+	}
 	else if(strncmp(target_triple, "armv7k", n) == 0 ||
 	        strncmp(target_triple, "thumbv7k", n) == 0){
 	    arch_flag->cputype = CPU_TYPE_ARM;
 	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V7K;
+	}
+	else if(strncmp(target_triple, "armv7m", n) == 0 ||
+	        strncmp(target_triple, "thumbv7m", n) == 0){
+	    arch_flag->cputype = CPU_TYPE_ARM;
+	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V7M;
+	}
+	else if(strncmp(target_triple, "armv7em", n) == 0 ||
+	        strncmp(target_triple, "thumbv7em", n) == 0){
+	    arch_flag->cputype = CPU_TYPE_ARM;
+	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V7EM;
+	}
+	else if(strncmp(target_triple, "arm64", n) == 0){
+	    arch_flag->cputype = CPU_TYPE_ARM64;
+	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM64_ALL;
 	}
 	else{
 	    return(0);

--- a/libstuff/reloc.c
+++ b/libstuff/reloc.c
@@ -73,6 +73,12 @@ cpu_type_t cputype)
 	case CPU_TYPE_ARM:
 	    return(ARM_RELOC_PAIR);
 	    break;
+	case CPU_TYPE_ARM64:
+	    /*
+	     * We should never hit this case for arm64, so drop down to the
+	     * fatal error below.
+	     */
+	    break;
 	}
 	fatal("internal error: reloc_pair_r_type() called with unknown "
 	      "cputype (%u)", cputype);
@@ -153,6 +159,8 @@ uint32_t r_type)
 	       r_type == ARM_RELOC_HALF_SECTDIFF)
 		return(TRUE);
 	    break;
+	case CPU_TYPE_ARM64:
+	    return(FALSE);
 	default:
 	    fatal("internal error: reloc_has_pair() called with unknown "
 		  "cputype (%u)", cputype);
@@ -217,6 +225,10 @@ uint32_t r_type)
 	       r_type == ARM_RELOC_HALF_SECTDIFF)
 		return(TRUE);
 	    break;
+	case CPU_TYPE_ARM64:
+		/* No sectdiff relocs for arm64. */
+		return(FALSE);
+		break;
 	default:
 	    fatal("internal error: reloc_is_sectdiff() called with unknown "
 		  "cputype (%u)", cputype);

--- a/preinc.h
+++ b/preinc.h
@@ -34,7 +34,6 @@ struct __darwin_i386_float_state;
 #define __uint32_t uint32_t
 #define __lr lr
 #define __pc pc
-#include "mach/arm/_structs.h"
 #undef __pc
 #undef __lr
 #undef __uint32_t

--- a/strip.c
+++ b/strip.c
@@ -1365,6 +1365,17 @@ struct object *object)
 		    object->code_sign_drs_cmd->datasize;
 	    }
 
+	    if(object->link_opt_hint_cmd != NULL){
+		object->output_link_opt_hint_info_data = object->object_addr +
+		    object->link_opt_hint_cmd->dataoff;
+		object->output_link_opt_hint_info_data_size = 
+		    object->link_opt_hint_cmd->datasize;
+		object->input_sym_info_size +=
+		    object->link_opt_hint_cmd->datasize;
+		object->output_sym_info_size +=
+		    object->link_opt_hint_cmd->datasize;
+	    }
+
 	    if(object->mh != NULL){
 		object->input_sym_info_size += nsyms * sizeof(struct nlist);
 		object->output_symbols = new_symbols;
@@ -1610,6 +1621,11 @@ struct object *object)
 		if(object->code_sign_drs_cmd != NULL){
 		    object->code_sign_drs_cmd->dataoff = offset;
 		    offset += object->code_sign_drs_cmd->datasize;
+		}
+
+		if(object->link_opt_hint_cmd != NULL){
+		    object->link_opt_hint_cmd->dataoff = offset;
+		    offset += object->link_opt_hint_cmd->datasize;
 		}
 
 		if(object->st->nsyms != 0){
@@ -1865,6 +1881,8 @@ struct object *object)
 			      object->input_indirectsym_pad;
 		}
 	    }
+	    if(no_uuid == TRUE)
+		strip_LC_UUID_commands(arch, member, object);
 	}
 #endif /* !defined(NMEDIT) */
 
@@ -2141,6 +2159,18 @@ struct object *object)
 	       object->dyst->nlocrel != 0 &&
 	       object->dyst->locreloff < offset)
 		offset = object->dyst->locreloff;
+	    if(object->func_starts_info_cmd != NULL &&
+	       object->func_starts_info_cmd->datasize != 0 &&
+	       object->func_starts_info_cmd->dataoff < offset)
+	        offset = object->func_starts_info_cmd->dataoff;
+	    if(object->data_in_code_cmd != NULL &&
+	       object->data_in_code_cmd->datasize != 0 &&
+	       object->data_in_code_cmd->dataoff < offset)
+	        offset = object->data_in_code_cmd->dataoff;
+	    if(object->link_opt_hint_cmd != NULL &&
+	       object->link_opt_hint_cmd->datasize != 0 &&
+	       object->link_opt_hint_cmd->dataoff < offset)
+	        offset = object->link_opt_hint_cmd->dataoff;
 	    if(object->st->nsyms != 0 &&
 	       object->st->symoff < offset)
 		offset = object->st->symoff;
@@ -2564,10 +2594,7 @@ uint32_t nextrefsyms)
 	}
 
 	new_nsyms = 0;
-	if(object->mh != NULL)
-	    new_strsize = sizeof(int32_t);
-	else
-	    new_strsize = sizeof(int64_t);
+	new_strsize = sizeof(int32_t);
 	new_nlocalsym = 0;
 	new_nextdefsym = 0;
 	new_nundefsym = 0;
@@ -2575,7 +2602,10 @@ uint32_t nextrefsyms)
 
 	/*
 	 * If this an object file that has DWARF debugging sections to strip
-	 * then we have to run ld -r on it.
+	 * then we have to run ld -r on it.  We also have to do this for
+	 * ARM objects because thumb symbols can't be stripped as they are
+	 * needed for proper linking in .o files.  And we need to for i386
+	 * objects to not mess up compact unwind info.
 	 */
 	if(object->mh_filetype == MH_OBJECT && (Sflag || xflag)){
 	    has_dwarf = FALSE;
@@ -2611,7 +2641,14 @@ uint32_t nextrefsyms)
 		}
 		lc = (struct load_command *)((char *)lc + lc->cmdsize);
 	    }
-	    if(has_dwarf == TRUE)
+	    /*
+	     * If the file has dwarf symbols or is an ARM or i386 object then
+	     * have ld(1) do the "stripping" and make an ld -r version of the
+	     * object.
+	     */
+	    if(has_dwarf == TRUE ||
+	       object->mh_cputype == CPU_TYPE_ARM ||
+	       object->mh_cputype == CPU_TYPE_I386)
 		make_ld_r_object(arch, member, object);
 	}
 	/*
@@ -2741,12 +2778,14 @@ uint32_t nextrefsyms)
 	    }
 	    if((n_type & N_EXT) == 0){ /* local symbol */
 		/*
-		 * For x86_64 .o files we have run ld -r on them and are stuck
-		 * keeping all resulting symbols.
+		 * For x86_64, i386 .o or ARM files we have run ld -r on them
+		 * we keeping all resulting symbols.
 		 */
-		if(object->mh == NULL && (
-		   object->mh64->cputype == CPU_TYPE_X86_64) &&
-		   object->mh64->filetype == MH_OBJECT){
+		if((object->mh_cputype == CPU_TYPE_X86_64 ||
+		    object->mh_cputype == CPU_TYPE_I386 ||
+                    object->mh_cputype == CPU_TYPE_ARM64 ||
+		    object->mh_cputype == CPU_TYPE_ARM) &&
+		   object->mh_filetype == MH_OBJECT){
 		    if(n_strx != 0)
 			new_strsize += strlen(strings + n_strx) + 1;
 		    new_nlocalsym++;
@@ -3087,13 +3126,16 @@ uint32_t nextrefsyms)
 		    saves[i] = new_nsyms;
 		}
 		/*
-		 * For x86_64 .o files we have run ld -r on them and are stuck
-		 * keeping all resulting symbols.
+		 * For x86_64 and i386 .o files we have run ld -r on them and
+		 * are stuck keeping all resulting symbols.
 		 */
 		if(saves[i] == 0 &&
-		   object->mh == NULL && 
-		   object->mh64->cputype == CPU_TYPE_X86_64 &&
-		   object->mh64->filetype == MH_OBJECT){
+		   ((object->mh == NULL && 
+		     object->mh64->cputype == CPU_TYPE_X86_64 &&
+		     object->mh64->filetype == MH_OBJECT) ||
+		    (object->mh64 == NULL && 
+		     object->mh->cputype == CPU_TYPE_I386 &&
+		     object->mh->filetype == MH_OBJECT))){
 		    len = strlen(strings + n_strx) + 1;
 		    new_strsize += len;
 		    new_ext_strsize += len;
@@ -4120,6 +4162,10 @@ struct object *object)
 		object->code_sign_drs_cmd =
 				         (struct linkedit_data_command *)lc1;
 		break;
+	    case LC_LINKER_OPTIMIZATION_HINT:
+		object->link_opt_hint_cmd =
+				         (struct linkedit_data_command *)lc1;
+		break;
 	    case LC_CODE_SIGNATURE:
 		object->code_sig_cmd = (struct linkedit_data_command *)lc1;
 		break;
@@ -4239,6 +4285,10 @@ struct object *object)
 		break;
 	    case LC_DYLIB_CODE_SIGN_DRS:
 		object->code_sign_drs_cmd =
+				         (struct linkedit_data_command *)lc1;
+		break;
+	    case LC_LINKER_OPTIMIZATION_HINT:
+		object->link_opt_hint_cmd =
 				         (struct linkedit_data_command *)lc1;
 		break;
 	    }

--- a/update-cctools.sh
+++ b/update-cctools.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env VERSION=855 sh -x # <-- Update VERSION to correspond with drop.
+URI=http://opensource.apple.com/tarballs/cctools/cctools-$VERSION.tar.gz
+
+git checkout -b cctools-$VERSION 2>/dev/null || :
+
+cp strip.c tease.c; git diff -R --histogram -- tease.c > /tmp/tease.patch
+git checkout -- tease.c
+
+curl -L\# $URI | tar x --strip-components 1; git checkout -- Makefile
+
+for file in strip.c install_name_tool.c nm.c; do cp misc/$file .; done
+
+git clean -dfq;       git add -A . && git commit -am "Import cctools-$VERSION."
+cp strip.c tease.c;   git apply /tmp/tease.patch && success=yes || success=no
+[ $success = yes ] && git add -A . && git commit -am  "Apply cctools-$VERSION."
+
+[ $success = yes ] && exit 0 || git checkout -- tease.c; mv /tmp/tease.patch .
+echo "Could not auto-apply patch. See strip.c, tease.c, tease.patch." && exit 1

--- a/version.mak
+++ b/version.mak
@@ -1,5 +1,0 @@
-# The cctools version suffix these sources are based on
-# The tarball can be found at:
-# http://opensource.apple.com/tarballs/cctools/cctools-$(CCTOOLSVER).tar.gz
-
-CCTOOLSVER = 822


### PR DESCRIPTION
Briefly:
- Bring up to cctools-855. (Apple quietly made a substantial OSS drop (finally!) a couple of weeks ago, in case that didn't come up on your radar yet.)
  - All I've really done is a "dumb" diff-and-patch. (Git fails on one hunk, fixed manually.)
  - There's a shell script that basically does exactly what I did, for possible use in future maintenance.
  - Broken: `-no_uuid` SIGSEGVs. :crying_cat_face: Not a deal breaker for me personally, but...
  - Besides that, seems to work pretty well.
- Redo the makefile to allow building with, um, newer toolchains.
  - The "old" makefile is preserved for older machines via a switch in the makefile. 
  - Not version dependent: works without the rest of the patches.
- A couple other little things I'm forgetting. But that's the short of it.

Questions? Thoughts?

---

P.S. I'm a big fan of your projects — they're greatly under-apreciated I think. I use `tease`, `xar` 1.6, and `fakeroot` constantly. The standalone libBlocksRuntime is great too. Thanks! :smile: 
